### PR TITLE
Add endpoints and tests for room followers

### DIFF
--- a/fixtures/room-followers.json
+++ b/fixtures/room-followers.json
@@ -1,0 +1,56 @@
+[
+  {
+    "model": "User",
+    "data": {
+      "id": "follow_creator",
+      "username": "follow",
+      "email": "follow_creator@ripple.fm",
+      "password": "password",
+      "activated": true,
+      "isGuest": false
+    }
+  },
+  {
+    "model": "Room",
+    "data": {
+      "id": "follow-test",
+      "name": "Follow Test",
+      "playType": "public",
+      "accessType": "public",
+      "city": "Toronto",
+      "creatorId": "follow_creator",
+      "followers": [
+        {
+          "id": "follow_creator"
+        }
+      ]
+    }
+  },
+  {
+    "model": "User",
+    "data": {
+      "id": "unfollow_creator",
+      "username": "unfollow",
+      "email": "unfollow_creator@ripple.fm",
+      "password": "password",
+      "activated": true,
+      "isGuest": false
+    }
+  },
+  {
+    "model": "Room",
+    "data": {
+      "id": "unfollow-test",
+      "name": "Unfollow Test",
+      "playType": "public",
+      "accessType": "public",
+      "city": "Toronto",
+      "creatorId": "unfollow_creator",
+      "followers": [
+        {
+          "id": "unfollow_creator"
+        }
+      ]
+    }
+  }
+]

--- a/fixtures/seed.js
+++ b/fixtures/seed.js
@@ -27,6 +27,16 @@ const guestAccessToken = TokenService.signToken(
   '30m'
 );
 
+const followAccessToken = TokenService.signToken(
+  { id: 'follow_creator', username: 'follow' },
+  '30m'
+);
+
+const unfollowAccessToken = TokenService.signToken(
+  { id: 'unfollow_creator', username: 'unfollow' },
+  '30m'
+);
+
 export default {
   activationToken,
   resetToken,
@@ -35,5 +45,7 @@ export default {
   oldRefreshToken,
   accessToken,
   unactivatedAccessToken,
-  guestAccessToken
+  guestAccessToken,
+  followAccessToken,
+  unfollowAccessToken
 };

--- a/src/v1/controllers/room-controller.js
+++ b/src/v1/controllers/room-controller.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { BadRequestError } from '../errors';
 import wrap from '../../wrap';
+import followers from './room-followers-controller';
 import { authenticate } from './auth-controller';
 import verifyPagination from '../utils/verify-pagination';
 import RoomService from '../services/room-service';
@@ -14,6 +15,8 @@ roomRouter.use(
     next();
   })
 );
+
+roomRouter.use('/:id/followers', followers);
 
 roomRouter.get(
   '/',

--- a/src/v1/controllers/room-followers-controller.js
+++ b/src/v1/controllers/room-followers-controller.js
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import wrap from '../../wrap';
+import { authenticate } from './auth-controller';
+import { BadCredentialsError, BadRequestError } from '../errors';
+
+const followerRouter = Router();
+
+followerRouter.post(
+  '/',
+  authenticate,
+  wrap(async (req, res) => {
+    const { room, user } = req;
+    if (user.isGuest) {
+      throw BadCredentialsError('Guests are not able to follow rooms.');
+    } else if (await room.hasFollower(user.id)) {
+      throw BadRequestError('Already following this room.');
+    }
+    await room.addFollower(user.id);
+    res.status(201).json(room);
+  })
+);
+
+followerRouter.delete(
+  '/',
+  authenticate,
+  wrap(async (req, res) => {
+    const { room, user } = req;
+    if (await room.hasFollower(user.id)) {
+      await room.removeFollower(user.id);
+      res.status(204).end();
+    } else {
+      throw BadRequestError('Not following this room.');
+    }
+  })
+);
+
+export default followerRouter;

--- a/test/v1/controllers/room-followers-controller.test.js
+++ b/test/v1/controllers/room-followers-controller.test.js
@@ -1,0 +1,128 @@
+import mocha from 'mocha';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../../../src/index.js';
+import seed from '../../../fixtures/seed';
+
+chai.use(chaiHttp);
+const expect = chai.expect;
+
+describe('RoomFollowersController', function() {
+  describe('POST /rooms/:id/followers', function() {
+    it('should successfully follow a room', async function() {
+      const res = await chai
+        .request(server)
+        .post('/v1/rooms/follow-test/followers')
+        .set('Authorization', `Bearer ${seed.accessToken}`);
+      expect(res.status).to.eql(201);
+      expect(res.body).to.have.property('id');
+      expect(res.body.id).to.eql('follow-test');
+    });
+    it('should fail when already following a room', async function() {
+      try {
+        const res = await chai
+          .request(server)
+          .post('/v1/rooms/follow-test/followers')
+          .set('Authorization', `Bearer ${seed.followAccessToken}`);
+        throw res;
+      } catch (err) {
+        expect(err.status).to.eql(400);
+        expect(err.response.body).to.have.property('error');
+        expect(err.response.body.error).to.eql('Already following this room.');
+      }
+    });
+    it('should not allow a guest to follow a room', async function() {
+      try {
+        const res = await chai
+          .request(server)
+          .post('/v1/rooms/follow-test/followers')
+          .set('Authorization', `Bearer ${seed.guestAccessToken}`);
+        throw res;
+      } catch (err) {
+        expect(err.status).to.eql(401);
+        expect(err.response.body).to.have.property('error');
+        expect(err.response.body.error).to.eql(
+          'Guests are not able to follow rooms.'
+        );
+      }
+    });
+    it('should fail when sent invalid/missing access token', async function() {
+      try {
+        const res = await chai
+          .request(server)
+          .post('/v1/rooms/follow-test/followers');
+        throw res;
+      } catch (err) {
+        expect(err.status).to.eql(401);
+        expect(err.response.body).to.have.property('error');
+        expect(err.response.body.error).to.eql(
+          'Missing Authorization header in the form: "Authorization: Bearer <jwt>"'
+        );
+      }
+    });
+    it('should fail when trying to follow non-existent room', async function() {
+      try {
+        const res = await chai
+          .request(server)
+          .post('/v1/rooms/nothing-here/followers')
+          .set('Authorization', `Bearer ${seed.accessToken}`);
+        throw res;
+      } catch (err) {
+        expect(err.status).to.eql(404);
+        expect(err.response.body).to.have.property('error');
+        expect(err.response.body.error).to.eql('Room with given id not found.');
+      }
+    });
+  });
+
+  describe('DELETE /rooms/:id/followers', function() {
+    it('should successfully unfollow a room', async function() {
+      const res = await chai
+        .request(server)
+        .del('/v1/rooms/unfollow-test/followers')
+        .set('Authorization', `Bearer ${seed.unfollowAccessToken}`);
+      expect(res.status).to.eql(204);
+      expect(res.body).to.be.empty;
+    });
+    it('should fail when user does not follow the room', async function() {
+      try {
+        const res = await chai
+          .request(server)
+          .del('/v1/rooms/unfollow-test/followers')
+          .set('Authorization', `Bearer ${seed.guestAccessToken}`);
+        throw res;
+      } catch (err) {
+        expect(err.status).to.eql(400);
+        expect(err.response.body).to.have.property('error');
+        expect(err.response.body.error).to.eql('Not following this room.');
+      }
+    });
+    it('should fail when sent invalid/missing access token', async function() {
+      try {
+        const res = await chai
+          .request(server)
+          .del('/v1/rooms/unfollow-test/followers');
+        throw res;
+      } catch (err) {
+        expect(err.status).to.eql(401);
+        expect(err.response.body).to.have.property('error');
+        expect(err.response.body.error).to.eql(
+          'Missing Authorization header in the form: "Authorization: Bearer <jwt>"'
+        );
+      }
+    });
+    it('should fail when trying to unfollow non-existent room', async function() {
+      try {
+        const res = await chai
+          .request(server)
+          .del('/v1/rooms/nothing-here/followers')
+          .set('Authorization', `Bearer ${seed.accessToken}`);
+        throw res;
+      } catch (err) {
+        expect(err.status).to.eql(404);
+        expect(err.response.body).to.have.property('error');
+        expect(err.response.body.error).to.eql('Room with given id not found.');
+      }
+    });
+  });
+});


### PR DESCRIPTION
Adds two endpoints, both require valid registered user authentication:

> POST /rooms/:id/followers

user will follow the room

> DELETE /rooms/:id/followers

user will unfollow the room